### PR TITLE
Fix for UnsupportedCharsetException: UTF-32BE

### DIFF
--- a/authorization.yml
+++ b/authorization.yml
@@ -22,6 +22,7 @@ rules:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  namespace: jvmoperator
   name: operator-service
 ---
 kind: ClusterRoleBinding

--- a/src/main/resources/META-INF/native-image/ch.frankel.blog/jvm-operator/native-image.properties
+++ b/src/main/resources/META-INF/native-image/ch.frankel.blog/jvm-operator/native-image.properties
@@ -4,4 +4,5 @@ Args=  -J-Xmx3072m \
        --no-fallback \
        --no-server \
        -H:EnableURLProtocols=https \
-       -H:ConfigurationFileDirectories=/var/config
+       -H:ConfigurationFileDirectories=/var/config \
+       -H:+AddAllCharsets


### PR DESCRIPTION
During the session https://www.youtube.com/watch?v=Kxyz26CeoFo, an UnsupportedCharsetException prevented the operator from running successfully. After some research, it happens to be a graalvm-okhttp issue [issue with okhttp with graalvm-ce-19.0.0](https://github.com/oracle/graal/issues/1294)

Making all hosted charsets available at run time fixes the issue.

On top of that, I found myself in trouble when creating the service account, since (at least for me running a local minikube) the account was being created in the `default` namespace and the deployment could not find it as it was targeting some other `jvmoperator` namespace, producing an error when applying the yaml.

Targeting the service account to the specific namespace looks like a good practice too.

Thanks for your content.